### PR TITLE
Do not copy assets if Sphinx build is failed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+1.0.1 (unreleased)
+``````````````````
+
+- Do not copy assets (i.e. ``redoc.js``) to output directory if Sphinx build
+  has finished with errors (:issue:`1`).
+
 1.0.0 (2017-04-08)
 ``````````````````
 

--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -56,9 +56,13 @@ def render(app):
 
 
 def assets(app, exception):
-    copyfile(
-        os.path.join(here, 'redoc.js'),
-        os.path.join(app.builder.outdir, '_static', 'redoc.js'))
+    # Since '_static' directory may not exist in case of failed build, we
+    # need to either ensure its existence here or do not try to copy  assets
+    # in case of failure.
+    if not exception:
+        copyfile(
+            os.path.join(here, 'redoc.js'),
+            os.path.join(app.builder.outdir, '_static', 'redoc.js'))
 
 
 def setup(app):


### PR DESCRIPTION
If Sphinx has finished with errors there's no guarantee that `_static`
directory exists. So it's better to avoid copying of assets to `_static`
or we can end up with "No such file or directory" exception.

Fixes #1