### PR TITLE
Add support for some ReDoc options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,16 @@
+1.1.0 (2017-04-12)
+``````````````````
+
+- Add support for the following ReDoc options:
+
+  - ``lazy-rendering``
+  - ``suppress-warnings``
+  - ``hide-hostname``
+  - ``required-props-first``
+  - ``expand-responses``
+
+  [:issue:`4`, :pr:`5`]
+
 1.0.1 (2017-04-10)
 ``````````````````
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,9 @@ redoc = [
         'name': 'Github API (v3)',
         'page': 'api/github/index',
         'spec': '_specs/github.yml',
+        'opts': {
+            'lazy-rendering': True
+        },
     },
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,13 @@ do is to:
               'name': 'Example API',
               'page': 'example/index',
               'spec': 'http://example.com/openapi.yml',
+              'opts' {
+                  'lazy': False,
+                  'nowarnings': False,
+                  'nohostname': False,
+                  'required-props-first': True,
+                  'expand-responses': [200, 201],
+              }
           },
       ]
 
@@ -66,6 +73,30 @@ do is to:
   ``spec``
     A path to an OpenAPI spec to be rendered. Can be either an HTTP(s)
     link to external source, or filesystem path relative to conf directory.
+
+  ``opts``
+    An optional dictionary with some of ReDoc settings that might be
+    useful. Here they are
+
+    ``lazy-rendering`` (default: ``False``)
+      If set, enables lazy rendering mode which is useful for APIs with big
+      number of operations (e.g. > 50). In this mode ReDoc shows initial
+      screen ASAP and then renders the rest operations asynchronously while
+      showing progress bar on the top.
+
+    ``suppress-warnings`` (default: ``False``)
+      If set, no warnings are rendered at the top of the document.
+
+    ``hide-hostname`` (default: ``False``)
+      If set, both protocol ans hostname are not shown in the operational
+      definition.
+
+    ``required-props-first`` (default: ``False``)
+      If set, ReDoc shows required properties first in the same order as in
+      ``required`` array. Please note, it may be slow.
+
+    ``expand-responses`` (default: ``[]``)
+      A list of response codes to be expanded by default.
 
 
 Demo

--- a/sphinxcontrib/redoc.j2
+++ b/sphinxcontrib/redoc.j2
@@ -9,7 +9,13 @@
     </style>
   </head>
   <body>
-    <redoc spec-url="{{ pathto(spec, 1) }}"></redoc>
+    <redoc spec-url="{{ pathto(spec, 1) }}"
+           {{ 'lazy-rendering' if opts['lazy-rendering'] }}
+           {{ 'suppress-warnings' if opts['suppress-warnings'] }}
+           {{ 'hide-hostname' if opts['hide-hostname'] }}
+           {{ 'required-props-first' if opts['required-props-first'] }}
+           {{ 'expand-responses="%s"' % ','.join(opts['expand-responses']) }}>
+    </redoc>
     <script src="{{ pathto('_static/redoc.js', 1) }}"></script>
   </body>
 </html>

--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -26,6 +26,15 @@ with io.open(os.path.join(here, 'redoc.j2'), 'r', encoding='utf-8') as f:
 
 def render(app):
     for ctx in app.config.redoc:
+        # Setup options if they are not passed since 'redoc.j2' template
+        # relies on them.
+        ctx.setdefault('opts', {})
+        ctx['opts'].setdefault('lazy-rendering', False)
+        ctx['opts'].setdefault('suppress-warnings', False)
+        ctx['opts'].setdefault('hide-hostname', False)
+        ctx['opts'].setdefault('required-props-first', False)
+        ctx['opts'].setdefault('expand-responses', [])
+
         # The 'spec' may contain either HTTP(s) link or filesystem path. In
         # case of later we need to copy the spec into output directory, as
         # otherwise it won't be available when the result is deployed.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,8 +44,9 @@ def test_redocjs_page_is_generated(sphinxdocs):
 
     html = outdir.join('api', 'github', 'index.html').read()
     patterns = [
-        r'<redoc spec-url="../../_specs/github.yml"></redoc>',
-        r'<script src="../../_static/redoc.js">',
+        r'<redoc spec-url="../../_specs/github.yml"\s+lazy-rendering\s+'
+        r'expand-responses="">\s*</redoc>',
+        r'<script src="../../_static/redoc.js">\s*</script>',
     ]
 
     for pattern in patterns:


### PR DESCRIPTION
So far `sphinxcontrib-redoc` didn't support any of ReDoc options and
fully relied on defaults. That's inconvenient in one cases and limits
users in another. In order to overcome this inconvenience, this patch
adds a new `redoc['opts']` setting node with ReDoc options. Here's
what it supports:

 * `lazy-rendering`
 * `suppress-warnings`
 * `hide-hostname`
 * `required-props-first`
 * `expand-responses`

Fixes #4