### PR TITLE
Add support for new ReDoc options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 ``````````````````
 - Update ``redoc.js`` to ``1.14.0``. [:pr:`6`]
 
+- Add support for the following ReDoc options:
+
+  - ``no-auto-auth``
+  - ``path-in-middle-panel``
+
+  [:pr:`7`]
+
 1.1.0 (2017-04-12)
 ``````````````````
 

--- a/sphinxcontrib/redoc.j2
+++ b/sphinxcontrib/redoc.j2
@@ -14,6 +14,8 @@
            {{ 'suppress-warnings' if opts['suppress-warnings'] }}
            {{ 'hide-hostname' if opts['hide-hostname'] }}
            {{ 'required-props-first' if opts['required-props-first'] }}
+           {{ 'no-auto-auth' if opts['no-auto-auth'] }}
+           {{ 'path-in-middle-panel' if opts['path-in-middle-panel'] }}
            {{ 'expand-responses="%s"' % ','.join(opts['expand-responses']) }}>
     </redoc>
     <script src="{{ pathto('_static/redoc.js', 1) }}"></script>

--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -33,6 +33,8 @@ def render(app):
         ctx['opts'].setdefault('suppress-warnings', False)
         ctx['opts'].setdefault('hide-hostname', False)
         ctx['opts'].setdefault('required-props-first', False)
+        ctx['opts'].setdefault('no-auto-auth', False)
+        ctx['opts'].setdefault('path-in-middle-panel', False)
         ctx['opts'].setdefault('expand-responses', [])
 
         # The 'spec' may contain either HTTP(s) link or filesystem path. In


### PR DESCRIPTION
In ReDoc v1.14.0 there are new options we don't support yet:

 * `no-auto-auth`
 * `path-in-middle-panel`

This commit adds support for them, i.e. propagates them from Sphinx's
`conf.py` to ReDoc.