### PR TITLE
Add an 'offline' option to embed the spec in the rendered page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ do is to:
               'name': 'Batcomputer API',
               'page': 'api',
               'spec': 'specs/batcomputer.yml',
+              'embed': True,
           },
           {
               'name': 'Example API',
@@ -73,6 +74,13 @@ do is to:
   ``spec``
     A path to an OpenAPI spec to be rendered. Can be either an HTTP(s)
     link to external source, or filesystem path relative to conf directory.
+
+  ``embed`` (default: ``False``)
+    If ``True``, the ``spec`` will be embedded into the rendered HTML page.
+    Useful for cases when a browsable API ready to be used without any web
+    server is needed.
+    The ``spec`` must be an ``UTF-8`` encoded JSON on YAML OpenAPI spec;
+    embedding an external ``spec`` is currently not supported.
 
   ``opts``
     An optional dictionary with some of ReDoc settings that might be

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'jinja2 >= 2.4',
         'sphinx >= 1.5',
         'six >= 1.5',
+        'PyYAML >= 3.12',
     ],
     classifiers=[
         'Topic :: Documentation',

--- a/sphinxcontrib/redoc.j2
+++ b/sphinxcontrib/redoc.j2
@@ -29,7 +29,11 @@
     </script>
     {% endif %}
     <script>
-        var spec = {{ 'JSON.parse(document.getElementById("spec").innerHTML)' if embed else spec }}
+        {% if embed %}
+        var spec = JSON.parse(document.getElementById("spec").innerHTML);
+        {% else %}
+        var spec = "{{ spec }}";
+        {% endif %}
         Redoc.init(spec);
     </script>
   </body>

--- a/sphinxcontrib/redoc.j2
+++ b/sphinxcontrib/redoc.j2
@@ -10,9 +10,6 @@
   </head>
   <body>
     <redoc
-           {% if not offline %}
-           spec-url="{{ pathto(spec, 1) }}"
-           {% endif %}
            {{ 'lazy-rendering' if opts['lazy-rendering'] }}
            {{ 'suppress-warnings' if opts['suppress-warnings'] }}
            {{ 'hide-hostname' if opts['hide-hostname'] }}
@@ -24,15 +21,16 @@
            {{ 'untrusted-spec' if opts['untrusted-spec'] }}
            {{ 'expand-responses="%s"' % ','.join(opts['expand-responses']) if opts['expand-responses'] }}>
     </redoc>
+
     <script src="{{ pathto('_static/redoc.js', 1) }}"></script>
-    {% if offline %}
+    {% if embed %}
     <script type="application/json" id="spec">
     {{ spec }}
     </script>
+    {% endif %}
     <script>
-        var spec = JSON.parse(document.getElementById("spec").innerHTML)
+        var spec = {{ 'JSON.parse(document.getElementById("spec").innerHTML)' if embed else spec }}
         Redoc.init(spec);
     </script>
-    {% endif %}
   </body>
 </html>

--- a/sphinxcontrib/redoc.j2
+++ b/sphinxcontrib/redoc.j2
@@ -9,7 +9,10 @@
     </style>
   </head>
   <body>
-    <redoc spec-url="{{ pathto(spec, 1) }}"
+    <redoc
+           {% if not offline %}
+           spec-url="{{ pathto(spec, 1) }}"
+           {% endif %}
            {{ 'lazy-rendering' if opts['lazy-rendering'] }}
            {{ 'suppress-warnings' if opts['suppress-warnings'] }}
            {{ 'hide-hostname' if opts['hide-hostname'] }}
@@ -22,5 +25,14 @@
            {{ 'expand-responses="%s"' % ','.join(opts['expand-responses']) if opts['expand-responses'] }}>
     </redoc>
     <script src="{{ pathto('_static/redoc.js', 1) }}"></script>
+    {% if offline %}
+    <script type="application/json" id="spec">
+    {{ spec }}
+    </script>
+    <script>
+        var spec = JSON.parse(document.getElementById("spec").innerHTML)
+        Redoc.init(spec);
+    </script>
+    {% endif %}
   </body>
 </html>

--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -32,11 +32,13 @@ def render(app):
         # relies on them.
         ctx.setdefault('opts', {})
 
-        # "Embed" mode: the JSON spec is embedded in the page
-        # TODO: only works for local files: add remote files download ?
+        # In embed mode, we are going to embed the whole OpenAPI spec into
+        # produced HTML. The rationale is very simple: we want to produce
+        # browsable HTMLs ready to be used without any web server.
         if ctx.get('embed') is True:
             # Parse & dump the spec to have it as properly formatted json
-            with io.open(os.path.join(app.confdir, ctx['spec'])) as specfp:
+            specfile = os.path.join(app.confdir, ctx['spec'])
+            with io.open(specfile, encoding='utf-8') as specfp:
                 try:
                     spec_contents = yaml.load(specfp)
                 except ValueError as ver:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -144,14 +144,17 @@ def test_redocjs_page_is_generated(run_sphinx, tmpdir, options, attributes):
     html = tmpdir.join('out').join('api', 'github', 'index.html').read()
     soup = bs4.BeautifulSoup(html, 'html.parser')
 
+    # spec url is passed directly as the first arg to the redoc init
+    del attributes["spec-url"]
+
     assert soup.title.string == 'Github API (v3)'
     assert soup.redoc.attrs == attributes
     assert soup.script.attrs['src'] == os.path.join(
         '..', '..', '_static', 'redoc.js')
 
 
-def test_offline_embedded_js(run_sphinx, tmpdir):
-    run_sphinx({}, conf={'offline': True})
+def test_embedded_spec(run_sphinx, tmpdir):
+    run_sphinx({}, conf={'embed': True})
     html = tmpdir.join('out').join('api', 'github', 'index.html').read()
     specfile = tmpdir.join('src', '_specs', 'github.yml')
     soup = bs4.BeautifulSoup(html, 'html.parser')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,5 @@
 import os
 import textwrap
-import pprint
 import yaml
 import json
 import py
@@ -41,7 +40,7 @@ def run_sphinx(tmpdir):
             source_suffix = '.rst'
             master_doc = 'index'
             redoc = {{ redoc }}
-        ''')).render(redoc=pprint.pformat([defaultconf]))
+        ''')).render(redoc=[defaultconf])
 
         src.join('conf.py').write_text(confpy, encoding='utf-8')
         src.join('index.rst').ensure()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,8 @@
 import os
 import textwrap
-
+import pprint
+import yaml
+import json
 import py
 import pytest
 import pkg_resources
@@ -21,7 +23,14 @@ def run_sphinx(tmpdir):
     spec = py.path.local(here).join('..', 'docs', '_specs', 'github.yml')
     spec.copy(src.mkdir('_specs').join('github.yml'))
 
-    def run(conf):
+    def run(redoc_options, conf=None):
+        defaultconf = {'name': 'Github API (v3)',
+                       'page': 'api/github/index',
+                       'spec': '_specs/github.yml',
+                       }
+        if conf:
+            defaultconf.update(conf)
+        defaultconf['opts'] = redoc_options
         confpy = jinja2.Template(textwrap.dedent('''
             import os
 
@@ -31,21 +40,9 @@ def run_sphinx(tmpdir):
             extensions = ['sphinxcontrib.redoc']
             source_suffix = '.rst'
             master_doc = 'index'
-            redoc = [
-                {
-                    'name': 'Github API (v3)',
-                    'page': 'api/github/index',
-                    'spec': '_specs/github.yml',
-                    {% if opts is not none %}
-                    'opts': {
-                        {% for key, value in opts.items() %}
-                        '{{ key }}': {{ value }},
-                        {% endfor %}
-                    },
-                    {% endif %}
-                },
-            ]
-        ''')).render(opts=conf)
+            redoc = {{ redoc }}
+        ''')).render(redoc=pprint.pformat([defaultconf]))
+
         src.join('conf.py').write_text(confpy, encoding='utf-8')
         src.join('index.rst').ensure()
 
@@ -151,3 +148,18 @@ def test_redocjs_page_is_generated(run_sphinx, tmpdir, options, attributes):
     assert soup.redoc.attrs == attributes
     assert soup.script.attrs['src'] == os.path.join(
         '..', '..', '_static', 'redoc.js')
+
+
+def test_offline_embedded_js(run_sphinx, tmpdir):
+    run_sphinx({}, conf={'offline': True})
+    html = tmpdir.join('out').join('api', 'github', 'index.html').read()
+    specfile = tmpdir.join('src', '_specs', 'github.yml')
+    soup = bs4.BeautifulSoup(html, 'html.parser')
+
+    with open(str(specfile)) as fp:
+        original_spec = yaml.load(fp)
+
+    embedded_spec = soup.find(id='spec').get_text()
+    # ensure the embedded spec is present and corresponds to the original
+    assert embedded_spec
+    assert json.loads(embedded_spec) == original_spec

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest
     flake8
     beautifulsoup4
+    pyyaml
 commands =
     {envpython} setup.py check --strict
     {envpython} -m flake8 {posargs:.}


### PR DESCRIPTION
Hello,

First of all thanks for the work you've put in this project, it has been really useful to me.

However, I desperately needed to be able to generate a completely static HTML page that doesn't load the spec externally, and:

- Redoc understandably doesn't support loading `file://` URLs
- starting a local http server would be waaay overkill
- `redoc-cli` can do it, but requires a whole load of various Javascript libraries & isn't integrated into Sphinx

See: Rebilly/ReDoc#149

I figured embedding the JSON spec in a `<script>` element would be the way to go. I haven't altered the default behavior, just added an `offline` parameter.

So what is does is, if the `offline` parameter is set to `True`, parse the JSON or YAML spec and embed it in the rendered page. Doesn't work for remote URLs, but I could fix that if you're interested.

Could you please consider merging ? Not yet though, I would like to update the docs first, if you're okay with it.

Thanks a lot !