### PR TITLE
Add 'redoc_uri' Sphinx option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,13 @@
 ``````````````````
 
 - New ``embed`` option. When ``True``, the spec will be embedded into the
-  rendered HTML page. Thanks `@etene <https://github.com/etene>`_.  [:pr:`14`]
+  rendered HTML page. Thanks `@etene <https://github.com/etene>`_.
+
+  [:pr:`14`]
+
+- Add ``redoc_uri`` Sphinx option to override default ``redoc.js``.
+
+  [:issue:`13`, :pr:`16`]
 
 1.4.0 (2018-03-24)
 ``````````````````
@@ -24,6 +30,7 @@
 
 1.2.0 (2017-04-24)
 ``````````````````
+
 - Update ``redoc.js`` to ``1.14.0``. [:pr:`6`]
 
 - Add support for the following ReDoc options:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,6 +117,12 @@ do is to:
       If set, the spec is considered untrusted and all HTML/markdown is
       sanitized to prevent XSS.
 
+* if you are not ok with default version, specify the one you want to use
+
+  .. code:: python
+
+      redoc_uri = 'https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js'
+
 Demo
 ----
 

--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -17,6 +17,7 @@ import yaml
 import jinja2
 import pkg_resources
 
+from six.moves import urllib
 from sphinx.util.osutil import copyfile, ensuredir
 
 
@@ -86,9 +87,19 @@ def assets(app, exception):
             os.path.join(here, 'redoc.js'),
             os.path.join(app.builder.outdir, '_static', 'redoc.js'))
 
+        # It's hard to keep up with ReDoc releases, especially when you don't
+        # watch them closely. Hence, there should be a way to override built-in
+        # ReDoc bundle with some upstream one.
+        if app.config.redoc_uri:
+            urllib.request.urlretrieve(
+                app.config.redoc_uri,
+                os.path.join(app.builder.outdir, '_static', 'redoc.js'))
+
 
 def setup(app):
     app.add_config_value('redoc', [], 'html')
+    app.add_config_value('redoc_uri', None, 'html')
+
     app.connect('html-collect-pages', render)
     app.connect('build-finished', assets)
 


### PR DESCRIPTION
Sometimes you don't want to wait for official release to get updated
redoc.js. Even more, sometimes maintainers do their job poorly and do
not update the library at once. So in order to be up-to-date, there
should be a way to override standard (distributed within this extension)
version of ReDoc by specifying third party one available somewhere in
the Internet.

Closes #13 