### PR TITLE
Adding a semicolon for conf.py options

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ do is to:
               'name': 'Example API',
               'page': 'example/index',
               'spec': 'http://example.com/openapi.yml',
-              'opts' {
+              'opts': {
                   'lazy': False,
                   'nowarnings': False,
                   'nohostname': False,


### PR DESCRIPTION
The missing semi-colon do not let you copy-paste the example.