### PR TITLE
DOC Fix expose-responses type

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ do is to:
                   'nowarnings': False,
                   'nohostname': False,
                   'required-props-first': True,
-                  'expand-responses': [200, 201],
+                  'expand-responses': ["200", "201"],
               }
           },
       ]


### PR DESCRIPTION
The documentation suggest to use,
```py
expand-responses = [200, 201]
```

This errored  for me with,
```
An error happened in rendering the page rest-api.
Reason: TypeError('sequence item 0: expected str instance, int found')
Reaping losing child 0x55b2c527c140 PID 18689
```

Using,
```py
expand-responses = ["200", "201"]
```
fixes it and works as expected as far as I can tell.