### PR TITLE
Load spec with safe_load to avoid triggering a pyyaml warning

### DIFF
--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -41,7 +41,7 @@ def render(app):
             specfile = os.path.join(app.confdir, ctx['spec'])
             with io.open(specfile, encoding='utf-8') as specfp:
                 try:
-                    spec_contents = yaml.load(specfp)
+                    spec_contents = yaml.safe_load(specfp)
                 except ValueError as ver:
                     raise ValueError('Cannot parse spec %r: %s'
                                      % (ctx['spec'], ver))


### PR DESCRIPTION
Hi,

Since I've upgraded PyYAML to 5.1, it [started issuing deprecation warnings](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) about not using `yaml.load`.

This pull request simply uses `safe_load` instead, which fixes the problem, and still works.