### PR TITLE
Add support for custom templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+1.6.0 (unreleased)
+``````````````````
+
+- Add support for custom ReDoc templates.
+
 1.5.1 (2018-08-05)
 ``````````````````
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,6 +82,16 @@ do is to:
     The ``spec`` must be an ``UTF-8`` encoded JSON on YAML OpenAPI spec;
     embedding an external ``spec`` is currently not supported.
 
+  ``template``
+    Non default template to use to render ReDoc HTML page. Must be either
+    passed, or omitted.
+
+    .. warning::
+
+       When custom template is used, settings such as ``name``, ``embed`` or
+       ``opts`` may not work if they are not supported by the template. Use
+       custom templates with caution.
+
   ``opts``
     An optional dictionary with some of ReDoc settings that might be
     useful. Here they are

--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -22,12 +22,7 @@ from six.moves import urllib
 from sphinx.util.osutil import copyfile, ensuredir
 
 
-here = os.path.abspath(os.path.dirname(__file__))
-
-with io.open(os.path.join(here, 'redoc.j2'), 'r', encoding='utf-8') as f:
-    template = jinja2.Template(f.read())
-
-
+_HERE = os.path.abspath(os.path.dirname(__file__))
 _REDOC_CONF_SCHEMA = {
     'type': 'array',
     'items': {
@@ -37,6 +32,7 @@ _REDOC_CONF_SCHEMA = {
             'page': {'type': 'string'},
             'spec': {'type': 'string'},
             'embed': {'type': 'boolean'},
+            'template': {'type': 'string'},
             'opts': {
                 'type': 'object',
                 'properties': {
@@ -79,6 +75,14 @@ def render(app):
         )
 
     for ctx in app.config.redoc:
+        if 'template' in ctx:
+            template_path = os.path.join(app.confdir, ctx['template'])
+        else:
+            template_path = os.path.join(_HERE, 'redoc.j2')
+
+        with io.open(template_path, encoding='utf-8') as f:
+            template = jinja2.Template(f.read())
+
         # In embed mode, we are going to embed the whole OpenAPI spec into
         # produced HTML. The rationale is very simple: we want to produce
         # browsable HTMLs ready to be used without any web server.
@@ -131,7 +135,7 @@ def assets(app, exception):
     # in case of failure.
     if not exception:
         copyfile(
-            os.path.join(here, 'redoc.js'),
+            os.path.join(_HERE, 'redoc.js'),
             os.path.join(app.builder.outdir, '_static', 'redoc.js'))
 
         # It's hard to keep up with ReDoc releases, especially when you don't


### PR DESCRIPTION
Custom templates may be pretty useful if someone wants to customize the
way how ReDoc page looks or just enhance it with some meta tags. From
now on, there's a way to pass a custom template.