### PR TITLE
fix missing build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ var/
 *.egg
 MANIFEST
 
+# IDE
+.idea/
+.vscode/
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -137,7 +137,7 @@ def assets(app, exception):
         build_dir = os.path.join(app.builder.outdir, '_static')
         redoc_js = os.path.join(build_dir, 'redoc.js')
         os.makedirs(build_dir, exist_ok=True)
-        copyfile(os.path.join(here, 'redoc.js'), redoc_js)
+        copyfile(os.path.join(_HERE, 'redoc.js'), redoc_js)
 
         # It's hard to keep up with ReDoc releases, especially when you don't
         # watch them closely. Hence, there should be a way to override built-in

--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -137,7 +137,7 @@ def assets(app, exception):
     if not exception:
         copy_asset(
             os.path.join(_HERE, 'redoc.js'),
-            os.path.join(app.builder.outdir, '_static', 'redoc.js'))
+            os.path.join(app.builder.outdir, '_static'))
 
         # It's hard to keep up with ReDoc releases, especially when you don't
         # watch them closely. Hence, there should be a way to override built-in

--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -136,7 +136,8 @@ def assets(app, exception):
     if not exception:
         build_dir = os.path.join(app.builder.outdir, '_static')
         redoc_js = os.path.join(build_dir, 'redoc.js')
-        os.makedirs(build_dir, exist_ok=True)
+        if not os.path.isdir(build_dir):
+            os.makedirs(build_dir)
         copyfile(os.path.join(_HERE, 'redoc.js'), redoc_js)
 
         # It's hard to keep up with ReDoc releases, especially when you don't

--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -134,17 +134,16 @@ def assets(app, exception):
     # need to either ensure its existence here or do not try to copy  assets
     # in case of failure.
     if not exception:
-        copyfile(
-            os.path.join(_HERE, 'redoc.js'),
-            os.path.join(app.builder.outdir, '_static', 'redoc.js'))
+        build_dir = os.path.join(app.builder.outdir, '_static')
+        redoc_js = os.path.join(build_dir, 'redoc.js')
+        os.makedirs(build_dir, exist_ok=True)
+        copyfile(os.path.join(here, 'redoc.js'), redoc_js)
 
         # It's hard to keep up with ReDoc releases, especially when you don't
         # watch them closely. Hence, there should be a way to override built-in
         # ReDoc bundle with some upstream one.
         if app.config.redoc_uri:
-            urllib.request.urlretrieve(
-                app.config.redoc_uri,
-                os.path.join(app.builder.outdir, '_static', 'redoc.js'))
+            urllib.request.urlretrieve(app.config.redoc_uri, redoc_js)
 
 
 def setup(app):

--- a/sphinxcontrib/redoc.py
+++ b/sphinxcontrib/redoc.py
@@ -19,6 +19,7 @@ import pkg_resources
 import yaml
 
 from six.moves import urllib
+from sphinx.util.fileutil import copy_asset
 from sphinx.util.osutil import copyfile, ensuredir
 
 
@@ -134,17 +135,17 @@ def assets(app, exception):
     # need to either ensure its existence here or do not try to copy  assets
     # in case of failure.
     if not exception:
-        build_dir = os.path.join(app.builder.outdir, '_static')
-        redoc_js = os.path.join(build_dir, 'redoc.js')
-        if not os.path.isdir(build_dir):
-            os.makedirs(build_dir)
-        copyfile(os.path.join(_HERE, 'redoc.js'), redoc_js)
+        copy_asset(
+            os.path.join(_HERE, 'redoc.js'),
+            os.path.join(app.builder.outdir, '_static', 'redoc.js'))
 
         # It's hard to keep up with ReDoc releases, especially when you don't
         # watch them closely. Hence, there should be a way to override built-in
         # ReDoc bundle with some upstream one.
         if app.config.redoc_uri:
-            urllib.request.urlretrieve(app.config.redoc_uri, redoc_js)
+            urllib.request.urlretrieve(
+                app.config.redoc_uri,
+                os.path.join(app.builder.outdir, '_static', 'redoc.js'))
 
 
 def setup(app):


### PR DESCRIPTION
I encountered this issue when running Sphinx's linkcheck with this extension is loaded, but it could happen in another situation.

I run into a "missing dir" error when this part is reached : 
https://github.com/sphinx-contrib/redoc/blob/31d4abe00e0026de0915c855e94a67b8a4e8d01f/sphinxcontrib/redoc.py#L132-L139

According to the message, it seems the potential problem is known but was still not handled...
