### PR TITLE
Make tests green again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,11 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.7-dev
+    - python: 3.7
       env: TOXENV=py37
     - python: 3.6
       env: TOXENV=docs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 1.6.0 (unreleased)
 ``````````````````
 
-- Add support for custom ReDoc templates.
+- Add support for custom ReDoc templates. [:pr:`27`]
+- Drop Python 3.4 support. [:pr:`34`]
 
 1.5.1 (2018-08-05)
 ``````````````````

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -156,7 +156,7 @@ def test_redocjs_page_is_generated(run_sphinx, tmpdir, options, attributes):
         '..', '..', '_static', 'redoc.js')
 
     assert os.path.join('..', '..', '_specs', 'github.yml') \
-        in soup.find_all('script')[-1].text
+        in soup.find_all('script')[-1].string
 
 
 @pytest.mark.parametrize(['options', 'rendered'], [
@@ -233,7 +233,7 @@ def test_embedded_spec(run_sphinx, tmpdir):
     with io.open(spec, encoding='utf-8') as f:
         spec = yaml.safe_load(f)
 
-    embedded_spec = soup.find(id='spec').get_text()
+    embedded_spec = soup.find(id='spec').string
     assert json.loads(embedded_spec) == spec
 
 


### PR DESCRIPTION
Since BeautifulSoup4 v4.9.0 (2020-04-05) embedded CSS and Javascript is
now stored in distinct Stylesheet and Script tags, which are ignored by
methods like get_text() since most people don't consider this sort of
content to be 'text'. In order to get retrieve textual representation of
such nodes, one must need to use `.string` property.